### PR TITLE
read incremental.md spec if instructions=md

### DIFF
--- a/src/cli/command/prompt.js
+++ b/src/cli/command/prompt.js
@@ -61,8 +61,14 @@ module.exports = {
 				initial: "Suggest something"
 			});
 
-			// Start the internal prompt process
-			await generateFilesFromPrompt(promptReply.feedback);
+			// open a file called incremental.md in the current directory and get its contents
+			if(promptReply.feedback=='md') {
+				let incrementalNotes = fs.readFileSync("./incremental.md", "utf8");
+				await generateFilesFromPrompt(incrementalNotes);
+			} else {
+				// Start the internal prompt process
+				await generateFilesFromPrompt(promptReply.feedback);
+			}
 		}
 
 		// Due to a bug with mongodb hanging connections, 


### PR DESCRIPTION
This is an ugly quick hack but works for me, I created a file incremental.md with the spec of what I want it to do, type 'md' in the terminal and it reads the file

Ideally I want to have a folder with several files so I can add library documentation.
But an advanced system would use embeddings on the docs and library repos to create a more compact context.

Instead of reinventing the wheel its best to use llama-index and/or langchain to create the retrieval agent and smol only takes care of implementing changes in the repo.